### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,3 +9,6 @@ steps:
   - --source=.
   - --trigger-http
   - --runtime=python39
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
add the options:
By default, Cloud Build stores your build logs in a Google-created Cloud Storage bucket. You can view build logs stored in the Google-created Cloud Storage bucket